### PR TITLE
Improvements to bin/netuitived script and project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.rb]
+indent_style = space
+indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.coffee]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+Metrics/LineLength:
+  Max: 160 # 80*2 - you have a widescreen monitor, right?

--- a/bin/netuitived
+++ b/bin/netuitived
@@ -3,6 +3,9 @@ require 'drb/drb'
 require 'netuitived'
 require 'yaml'
 
+# Hook up signal traps so that we clean up if signalled
+Netuitived.trap_signals
+
 # Check command line arguments
 case ARGV[0]
 when 'run' # runs netuitived in the foreground

--- a/bin/netuitived
+++ b/bin/netuitived
@@ -1,57 +1,16 @@
 #!/usr/bin/env ruby
+require 'drb/drb'
+require 'netuitived'
 require 'yaml'
-gem_root= File.expand_path("../..", __FILE__)
-data=YAML.load_file "#{gem_root}/config/agent.yml"
-if ARGV[0] == "start"
-	written = false
-	elementName=ENV["NETUITIVED_ELEMENT_NAME"]
-	if(elementName == nil or elementName == "")
-		elementName = data["elementName"]
-		if(elementName == "elementName" or elementName == "")
-			puts "please enter an element name: "
-			elementName = STDIN.gets.chomp
-			data["elementName"] = elementName
-			written = true
-		end
-	end
-	apiId=ENV["NETUITIVED_API_ID"]
-	if(apiId == nil or apiId == "")
-		apiId = data["apiId"]
-		if(apiId == "apiId" or apiId == "")
-			puts "please enter an api key: "
-			apiId = STDIN.gets.chomp
-			data["apiId"] = apiId
-			written = true
-		end
-	end
-	if written
-		File.open("#{gem_root}/config/agent.yml", 'w') {|f| f.write data.to_yaml } 
-	end
-	require 'drb/drb'
-	netuitivedAddr=data["netuitivedAddr"]
-	netuitivedPort=data["netuitivedPort"]
-	SERVER_URI="druby://#{netuitivedAddr}:#{netuitivedPort}"
-	DRb.start_service
-	begin
-		DRbObject.new_with_uri(SERVER_URI).stopServer
-		sleep(2)
-	rescue
-		
-	end
-    require 'netuitived'
-    puts "netuitived started"
-elsif ARGV[0] == "stop"
-	require 'drb/drb'
-	netuitivedAddr=data["netuitivedAddr"]
-	netuitivedPort=data["netuitivedPort"]
-	SERVER_URI="druby://#{netuitivedAddr}:#{netuitivedPort}"
-	DRb.start_service
-	begin
-		DRbObject.new_with_uri(SERVER_URI).stopServer
-		puts "netuitived stopped"
-	rescue
-		puts "netuitived isn't running"
-	end
+
+# Check command line arguments
+case ARGV[0]
+when 'run' # runs netuitived in the foreground
+  Netuitived.start(true)
+when 'start' # runs netuitived in the background
+  Netuitived.start
+when 'stop' # stops running netuitived
+  Netuitived.stop
 else
-    puts "invalid option. options are: start, stop"
+  puts 'invalid option. options are: run, start, stop'
 end

--- a/bin/netuitived
+++ b/bin/netuitived
@@ -3,9 +3,6 @@ require 'drb/drb'
 require 'netuitived'
 require 'yaml'
 
-# Hook up signal traps so that we clean up if signalled
-Netuitived.trap_signals
-
 # Check command line arguments
 case ARGV[0]
 when 'run' # runs netuitived in the foreground

--- a/lib/netuitive/scheduler.rb
+++ b/lib/netuitive/scheduler.rb
@@ -1,14 +1,15 @@
 require 'netuitive/netuitived_config_manager'
 require 'drb/drb'
+
 class Scheduler
 	def self.startSchedule
 		Thread.new do
   			while true do
   				sleep(ConfigManager.interval)
   				Thread.new do
-    				FRONT_OBJECT.sendMetrics
+    				Netuitived.front_object.sendMetrics
     			end
   			end
 		end
 	end
-end 
+end

--- a/lib/netuitived.rb
+++ b/lib/netuitived.rb
@@ -94,17 +94,6 @@ class Netuitived
       end
     end
 
-    ##
-    # Hooks up signal trapping so we cleanup gracefully if we can
-    def trap_signals
-      exit_handler = proc do
-        stop(true)
-      end
-
-      Signal.trap('INT', &exit_handler)
-      Signal.trap('TERM', &exit_handler)
-    end
-
     private
 
     ##

--- a/lib/netuitived.rb
+++ b/lib/netuitived.rb
@@ -1,12 +1,103 @@
-fork do
-	require 'netuitive/netuitived_config_manager'
-	require 'netuitive/scheduler'
-	require 'drb/drb'
-	require 'netuitive/netuitived_server'
-	ConfigManager::setup
-	Scheduler::startSchedule
-	NETUITIVE_URI="druby://#{ConfigManager.netuitivedAddr}:#{ConfigManager.netuitivedPort}"
-	FRONT_OBJECT=NetuitivedServer.new 
-	DRb.start_service(NETUITIVE_URI, FRONT_OBJECT)
-	DRb.thread.join
+require 'netuitive/netuitived_config_manager'
+require 'netuitive/scheduler'
+require 'drb/drb'
+require 'netuitive/netuitived_server'
+
+##
+# Provides facilities for running Netuitived
+class Netuitived
+  class << self
+    attr_reader :server_uri
+
+    ##
+    # The DRb front object
+    #
+    # @return [NetuitivedServer] The NetuitivedServer front object
+    def front_object
+      @front_object ||= NetuitivedServer.new
+    end
+
+    ##
+    # Checks that config values are provided and prompts for them if not
+    def interactively_check_config
+      gem_root = File.expand_path('../..', __FILE__)
+      data = YAML.load_file("#{gem_root}/config/agent.yml")
+
+      written = false
+      element_name = ENV['NETUITIVED_ELEMENT_NAME'] || data['elementName'] || ''
+
+      if element_name == 'elementName' || element_name == ''
+        puts 'please enter an element name: '
+        element_name = STDIN.gets.chomp
+        data['elementName'] = element_name
+        written = true
+      end
+
+      api_id = ENV['NETUITIVED_API_ID'] || data['apiId'] || ''
+
+      if api_id == 'apiId' || api_id == ''
+        puts 'please enter an api key: '
+        api_id = STDIN.gets.chomp
+        data['apiId'] = api_id
+        written = true
+      end
+
+      return unless written
+
+      File.open("#{gem_root}/config/agent.yml", 'w') { |f| f.write data.to_yaml }
+    end
+
+    ##
+    # Starts netuitived
+    #
+    # @param foreground [true, false] If true, run netuitived in the foreground
+    def start(foreground = false)
+      # Maintain the initial setup behavior
+      interactively_check_config
+
+      # Load the config from disk into ConfigManager
+      load_config
+
+      # Stop the service if it's already running
+      stop(true)
+
+      # Create a proc to run netuitived
+      runner = proc do
+        Scheduler.startSchedule
+        DRb.start_service(server_uri, front_object)
+        DRb.thread.join
+      end
+
+      if foreground
+        runner.call
+      else
+        fork(&runner)
+        puts 'netuitived started'
+      end
+    end
+
+    def stop(suppress_not_running_message = false)
+      load_config
+
+      DRb.start_service
+
+      begin
+        DRbObject.new_with_uri(@server_uri).stopServer
+        puts 'netuitived stopped'
+      rescue
+        puts "netuitived isn't running" unless suppress_not_running_message
+      end
+    end
+
+    private
+
+    ##
+    # Loads the configuration if necessary
+    def load_config
+      ConfigManager.setup unless @config_manager_setup
+
+      @config_manager_setup = true
+      @server_uri ||= "druby://#{ConfigManager.netuitivedAddr}:#{ConfigManager.netuitivedPort}".freeze
+    end
+  end
 end

--- a/lib/netuitived.rb
+++ b/lib/netuitived.rb
@@ -97,7 +97,7 @@ class Netuitived
     ##
     # Hooks up signal trapping so we cleanup gracefully if we can
     def trap_signals
-      exit_handler = Proc.new do
+      exit_handler = proc do
         stop(true)
       end
 

--- a/lib/netuitived.rb
+++ b/lib/netuitived.rb
@@ -69,6 +69,7 @@ class Netuitived
       end
 
       if foreground
+        puts 'netuitived running'
         runner.call
       else
         fork(&runner)
@@ -76,6 +77,10 @@ class Netuitived
       end
     end
 
+    ##
+    # Stops netuitived if it's running
+    #
+    # @param suppress_not_running_message [true, false] suppresses the "netuitived isn't running" message
     def stop(suppress_not_running_message = false)
       load_config
 
@@ -87,6 +92,17 @@ class Netuitived
       rescue
         puts "netuitived isn't running" unless suppress_not_running_message
       end
+    end
+
+    ##
+    # Hooks up signal trapping so we cleanup gracefully if we can
+    def trap_signals
+      exit_handler = Proc.new do
+        stop(true)
+      end
+
+      Signal.trap('INT', &exit_handler)
+      Signal.trap('TERM', &exit_handler)
     end
 
     private


### PR DESCRIPTION
This PR started off as me adding the ability to run netuitived in the foreground (a must for Docker) and turned into me cleaning up some stuff. The biggest change in this PR is that you can now run netuitived in the foreground. This change also makes it possible to run `netuitived` on platforms that Ruby doesn't support `fork` on (Windows, FreeBSD 4). 

List of changes:
- Added `.editorconfig`, which allows compatible editors to use the correct EOL and indent style
- Added `.rubocop.yml`, which configures Rubocop. Right now, I just set the line length maximum to 160, but this could be amended in the future.
- Changed `bin/netuitived` to be a very simple wrapper around a class defined in `lib/netuitived`. Added the `run` command, which runs `netuitived` in the foreground.
- Changed `lib/netuitived` to include a class which starts the daemon (optionally in the foreground), stops the daemon, and interactively configures the daemon (which is the current behavior if `netuitived` can't get a good configuration).
- Changed `lib/netuitive/scheduler` so that it doesn't rely on this library polluting global scope with `FRONT_OBJECT`
